### PR TITLE
updated clamav image tag

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,8 +2,23 @@ apiVersion: v1
 entries:
   clamav:
   - apiVersion: v2
+    appVersion: 1.9.50
+    created: "2023-02-20T08:16:42.796784-05:00"
+    description: An Open-Source antivirus engine for detecting trojans, viruses, malware
+      & other malicious threats.
+    digest: 05f6961211523b434ce8049ce96d53a49d283d47662fb1674923c7caf592b085
+    home: https://www.clamav.net
+    icon: https://www.clamav.net/assets/clamav-trademark.png
+    name: clamav
+    sources:
+    - https://github.com/Mailu/Mailu
+    type: application
+    urls:
+    - clamav-1.0.4.tgz
+    version: 1.0.4
+  - apiVersion: v2
     appVersion: "1.9"
-    created: "2022-08-29T15:56:40.613036-04:00"
+    created: "2023-02-20T08:16:42.796511-05:00"
     description: An Open-Source antivirus engine for detecting trojans, viruses, malware
       & other malicious threats.
     digest: 9d8f4bfa6a33cca4eaec3d59a1f48344bfb9c05351ea1e8bb92db8fb0448dc38
@@ -18,7 +33,7 @@ entries:
     version: 1.0.3
   - apiVersion: v1
     appVersion: "1.6"
-    created: "2022-08-29T15:56:40.612781-04:00"
+    created: "2023-02-20T08:16:42.796239-05:00"
     description: An Open-Source antivirus engine for detecting trojans, viruses, malware
       & other malicious threats.
     digest: 796b41cfb4b3bc2df6fac89801b3ccad66691fd9f46a00e2fb30e81b07575afe
@@ -33,7 +48,7 @@ entries:
     version: 1.0.2
   - apiVersion: v1
     appVersion: "1.6"
-    created: "2022-08-29T15:56:40.612527-04:00"
+    created: "2023-02-20T08:16:42.795962-05:00"
     description: An Open-Source antivirus engine for detecting trojans, viruses, malware
       & other malicious threats.
     digest: cbeee5ddb603dc71a111c784130dc432fbb5450cb7d3486a5e9e2c0a79108809
@@ -49,7 +64,7 @@ entries:
   letsencrypt-issuers:
   - apiVersion: v2
     appVersion: "2.1"
-    created: "2022-08-29T15:56:40.613566-04:00"
+    created: "2023-02-20T08:16:42.797447-05:00"
     description: A Helm to deploy LetsEncrypt ClusterIssuers for production and staging
     digest: 5c4b8a046dd93bafd26e34ac07e09a4f2f2e3fa361f5c8b93213b8a15ff394c6
     name: letsencrypt-issuers
@@ -58,7 +73,7 @@ entries:
     version: 3.0.0
   - apiVersion: v1
     appVersion: "2.1"
-    created: "2022-08-29T15:56:40.613464-04:00"
+    created: "2023-02-20T08:16:42.797314-05:00"
     description: A Helm to deploy LetsEncrypt ClusterIssuers for production and staging
     digest: feb5886fcdcf3c3a482735d6effc5045dbd7147446182313dccfa7d500512350
     name: letsencrypt-issuers
@@ -67,7 +82,7 @@ entries:
     version: 2.1.0
   - apiVersion: v1
     appVersion: "2.0"
-    created: "2022-08-29T15:56:40.61336-04:00"
+    created: "2023-02-20T08:16:42.797184-05:00"
     description: A Helm to deploy LetsEncrypt ClusterIssuers for production and staging
     digest: fa0d62227f1d32a716cf62474434a834ba2f25f561a94186779fc54b165fe331
     name: letsencrypt-issuers
@@ -76,7 +91,7 @@ entries:
     version: 2.0.1
   - apiVersion: v1
     appVersion: "2.0"
-    created: "2022-08-29T15:56:40.613256-04:00"
+    created: "2023-02-20T08:16:42.797055-05:00"
     description: A Helm to deploy LetsEncrypt ClusterIssuers for production and staging
     digest: e02afc226b54a701e820198895d5be8bbf270a21b012a61c8265bd14a8d2b131
     name: letsencrypt-issuers
@@ -85,7 +100,7 @@ entries:
     version: 2.0.0
   - apiVersion: v1
     appVersion: "1.0"
-    created: "2022-08-29T15:56:40.613144-04:00"
+    created: "2023-02-20T08:16:42.796922-05:00"
     description: A Helm to deploy LetsEncrypt ClusterIssuers for production and staging
     digest: 55f90d4b37b2eca7094dd0f90d7e989268d0315bfe43286c63973aba6254e98f
     name: letsencrypt-issuers
@@ -95,7 +110,7 @@ entries:
   maildev:
   - apiVersion: v2
     appVersion: 2.0.0-beta3
-    created: "2022-08-29T15:56:40.614096-04:00"
+    created: "2023-02-20T08:16:42.798047-05:00"
     description: A Helm chart for Kubernetes
     digest: 7912ca9dac9973b8aef12fc3c39df15640a5003b9a1c74b285242155fc443bbb
     name: maildev
@@ -105,7 +120,7 @@ entries:
     version: 0.2.0
   - apiVersion: v2
     appVersion: 2.0.0-beta3
-    created: "2022-08-29T15:56:40.613832-04:00"
+    created: "2023-02-20T08:16:42.797744-05:00"
     description: A Helm chart for Kubernetes
     digest: 824ea4aac7030c2684be037eea03ef3e3c30ebef08b7cc3cda9749b3af390cb7
     name: maildev
@@ -115,7 +130,7 @@ entries:
   tls-ingress:
   - apiVersion: v2
     appVersion: "3.0"
-    created: "2022-08-29T15:56:40.615266-04:00"
+    created: "2023-02-20T08:16:42.799452-05:00"
     description: This chart deploys an ingress that requests https certificates and
       routes traffic
     digest: 5ae966a6b8a62e823cc27bc65813c71b5ea73f138d1f59b803a85e159c9e62e7
@@ -125,7 +140,7 @@ entries:
     version: 4.1.0
   - apiVersion: v2
     appVersion: "3.0"
-    created: "2022-08-29T15:56:40.615116-04:00"
+    created: "2023-02-20T08:16:42.799282-05:00"
     description: This chart deploys an ingress that requests https certificates and
       routes traffic
     digest: ea1c5fc7d8e590dc68dd3c02a6947d3d2dd0653cb5068308bec871f5ec348e1b
@@ -135,7 +150,7 @@ entries:
     version: 4.0.0
   - apiVersion: v1
     appVersion: "3.0"
-    created: "2022-08-29T15:56:40.614979-04:00"
+    created: "2023-02-20T08:16:42.79912-05:00"
     description: This chart deploys an ingress that requests https certificates and
       routes traffic
     digest: 4130c6a5fd6db80bd69cb9a55c58d93987e565a08b4e102bf7b06d4599c00417
@@ -145,7 +160,7 @@ entries:
     version: 3.0.1
   - apiVersion: v1
     appVersion: "3.0"
-    created: "2022-08-29T15:56:40.614834-04:00"
+    created: "2023-02-20T08:16:42.798951-05:00"
     description: This chart deploys an ingress that requests https certificates and
       routes traffic
     digest: c6f0d28778d2f9d8786142f623bcda0d77a8311c7d79a7c489e4d95f01ce0539
@@ -155,7 +170,7 @@ entries:
     version: 3.0.0
   - apiVersion: v1
     appVersion: "2.2"
-    created: "2022-08-29T15:56:40.614685-04:00"
+    created: "2023-02-20T08:16:42.798739-05:00"
     description: This chart deploys an ingress that requests https certificates and
       routes traffic
     digest: 93262019e3d7e93b53cc3bf8c218cec85ec87f1c96586fd09a2f9724bbbd6b71
@@ -165,7 +180,7 @@ entries:
     version: 2.2.0
   - apiVersion: v1
     appVersion: "2.1"
-    created: "2022-08-29T15:56:40.614539-04:00"
+    created: "2023-02-20T08:16:42.798567-05:00"
     description: This chart deploys an ingress that requests https certificates and
       routes traffic
     digest: 29ecfa9d5caf2a35c2df2122831a47274fd223f803e586e222bda9cd84ae4ff9
@@ -175,7 +190,7 @@ entries:
     version: 2.1.1
   - apiVersion: v1
     appVersion: "2.1"
-    created: "2022-08-29T15:56:40.614386-04:00"
+    created: "2023-02-20T08:16:42.798397-05:00"
     description: This chart deploys an ingress that requests https certificates and
       routes traffic
     digest: b98fb0341b3ca168f6d6b4a3597522c3351e0381ac8dfb9533e55e70b963e777
@@ -185,7 +200,7 @@ entries:
     version: 2.1.0
   - apiVersion: v1
     appVersion: "2.0"
-    created: "2022-08-29T15:56:40.61424-04:00"
+    created: "2023-02-20T08:16:42.798226-05:00"
     description: This chart deploys an ingress that requests https certificates and
       routes traffic
     digest: baa3cd578305fad4b95fb8d61ade4ffde520374b19c69e9d8e370c953ced778f
@@ -193,4 +208,4 @@ entries:
     urls:
     - tls-ingress-2.0.4.tgz
     version: 2.0.4
-generated: "2022-08-29T15:56:40.612084-04:00"
+generated: "2023-02-20T08:16:42.795556-05:00"


### PR DESCRIPTION
This is a critical release. Recently two new CVE's have been discovered for clamav. The below two CVE for Clamav are addressed in this release:
[CVE-2023-20032](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20032):
Fixed a possible remote code execution vulnerability in the HFS+ file parser.
Issue affects versions 1.0.0 and earlier, 0.105.1 and earlier, and 0.103.7 and
earlier.

[CVE-2023-20052](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20052):
Fixed a possible remote information leak vulnerability in the DMG file parser.
Issue affects versions 1.0.0 and earlier, 0.105.1 and earlier, and 0.103.7 and
earlier.

The clamav image has been updated to alpine 3.17.2 which contains the new version of clamav that addresses these two CVE's.